### PR TITLE
Add Arch Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ git clone https://github.com/calo001/fondo.git && cd com.github.calo001.fondo
 ./app uninstall
 ```
 
+### Arch Linux
+Arch Linux users can find Fondo under the name [fondo-git](https://aur.archlinux.org/packages/fondo-git/) in the **AUR**:
+
+`$ aurman -S fondo-git`
+
 ### Development & Testing
 
 Fondo includes a script to simplify the development process. This script can be accessed in the main project directory through `./app`.


### PR DESCRIPTION
Arch Linux Support

I will support your application in Arch Linux. Please, consider to use 2 branchs: master (stable code), develop (development code).

Please add a section containing the following instruction:

## Arch Linux
Arch Linux users can find Fondo under the name [fondo-git](https://aur.archlinux.org/packages/fondo-git/) in the **AUR**:

`$ aurman -S fondo-git`