### PR TITLE
Fix schema is not installed

### DIFF
--- a/app
+++ b/app
@@ -2,6 +2,18 @@
 
 arg=$1
 
+function prepare_gschema {
+    mkdir ~/.cache/temp_gschemas 2> /dev/null
+    cp data/com.github.calo001.fondo.gschema.xml ~/.cache/temp_gschemas/
+    glib-compile-schemas ~/.cache/temp_gschemas/
+    export GSETTINGS_SCHEMA_DIR=~/.cache/temp_gschemas/
+}
+
+function clear_gschema {
+    rm ~/.cache/temp_gschemas/* 2> /dev/null
+}
+
+
 function initialize {
     meson build --prefix=/usr
     result=$?
@@ -43,6 +55,7 @@ function test {
 
 case $1 in
 "clean")
+    clear_gschema
     sudo rm -rf ./build
     ;;
 "generate-i18n")
@@ -71,6 +84,7 @@ case $1 in
     $command
     ;;
 "run")
+    prepare_gschema
     initialize
     ./com.github.calo001.fondo "${@:2}"
     ;;


### PR DESCRIPTION
When "./app run" runs without first running "./app install" the following error appears and the application does not start:

```
(com.github.calo001.fondo:8444): GLib-GIO-ERROR **: 12:17:43.626: Settings schema 'com.github.calo001.fondo' is not installed
```

This commit fix this error and application runs normally