### PR TITLE
Fixed app script error

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These dependencies must be present before building:
  - `libunity-dev`
 
 
-Use the App script to simplify installation by running `./app install-deps`
+Use the App script to simplify installation by running `./app install-deps`, in this case, make sure that `dpkg-dev` package is installed
  
  ### Building
 

--- a/app
+++ b/app
@@ -68,19 +68,12 @@ case $1 in
     sudo ninja install
     ;;
 "install-deps")
-    output=$((dpkg-checkbuilddeps ) 2>&1)
-    result=$?
-
-    if [ $result -eq 0 ]; then
-        echo "All dependencies are installed"
-        exit 0
-    fi
-
-    replace="sudo apt install"
-    pattern="(\([>=<0-9. ]+\))+"
-    sudo_replace=${output/dpkg-checkbuilddeps: error: Unmet build dependencies:/$replace}
-    command=$(sed -r -e "s/$pattern//g" <<< "$sudo_replace")
-    
+    checkdeps=$(which dpkg-checkbuilddeps)
+    output=$(($checkdeps ) 2>&1)
+    [ "$?" -eq "0" ] && echo "All dependencies are installed" && exit 0 ;
+    packages=$(echo "$output" | sed 's/dpkg-checkbuilddeps: erro: Unmet build dependencies: //g')
+    packages=$(echo "$packages" | sed -r -e 's/(\([>=<0-9. ]+\))+//g')
+    command="sudo apt install $packages"
     $command
     ;;
 "run")


### PR DESCRIPTION
When run on Ubuntu 18.04 the following exception occurs:

```
./app: linha 84: dpkg-checkbuilddeps: command not found
```
Even if `dpkg-checkbuilddeps` is present. This commit fixes this.

<hr>

And warns user for `dpkg-checkbuilddeps` installation on readme