### PR TITLE
Issue #63 - enhancement: added ability to change lockscreen wallpaper 

### DIFF
--- a/app
+++ b/app
@@ -58,9 +58,6 @@ case $1 in
     clear_gschema
     sudo rm -rf ./build
     ;;
-"test")
-    test
-    ;;
 "generate-i18n")
     initialize
     ninja com.github.calo001.fondo-pot

--- a/app
+++ b/app
@@ -58,6 +58,9 @@ case $1 in
     clear_gschema
     sudo rm -rf ./build
     ;;
+"test")
+    test
+    ;;
 "generate-i18n")
     initialize
     ninja com.github.calo001.fondo-pot
@@ -69,10 +72,10 @@ case $1 in
     ;;
 "install-deps")
     checkdeps=$(which dpkg-checkbuilddeps)
-    output=$(($checkdeps ) 2>&1)
+    output=$(${checkdeps[@]} 2>&1)
     [ "$?" -eq "0" ] && echo "All dependencies are installed" && exit 0 ;
-    packages=$(echo "$output" | sed 's/dpkg-checkbuilddeps: erro: Unmet build dependencies: //g')
-    packages=$(echo "$packages" | sed -r -e 's/(\([>=<0-9. ]+\))+//g')
+    packages=$(echo $output | sed 's/dpkg-checkbuilddeps: error: Unmet build dependencies: //g')
+    packages=$(echo $packages | sed -r -e 's/(\([>=<0-9. ]+\))+//g')
     command="sudo apt install $packages"
     $command
     ;;

--- a/src/configs/Constants.vala
+++ b/src/configs/Constants.vala
@@ -1,44 +1,44 @@
 /*
 * Copyright (C) 2018  Calo001 <calo_lrc@hotmail.com>
-* 
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published
 * by the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU Affero General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
+*
 */
 
 namespace App.Configs {
 
     /**
-     * The {@code Constants} class is responsible for defining all 
+     * The {@code Constants} class is responsible for defining all
      * the constants used in the application.
      *
      * @since 1.0.0
      */
     public class Constants {
-    
+
         // API KEY in development, this must to change on production release
         // * Already change to production key
 
         public abstract const string API_UNSPLASH = "https://api.unsplash.com/";
         public abstract const string GET = "photos/?client_id=";
         public abstract const string SEARCH = "search/";
-        
+
         // API KEY for production, only use this key in releases for AppCenter
         public abstract const string ACCESS_KEY_UNSPLASH = "db4d69677b2838dfc4f9ef73ee79dcde8412472617bc96adefde321bd08a76f2";
-        
+
         // API KEY for development, only use this key in updates and fixes
         //public abstract const string ACCESS_KEY_UNSPLASH = "51531311dfa090ab81321cd2655e73c59b3d952b5966ed42e861fa7d50da47e8";
-        
+
         public abstract const string URI_PAGE = API_UNSPLASH + GET + ACCESS_KEY_UNSPLASH;
         public abstract const string URI_SEARCH_PAGE = API_UNSPLASH + SEARCH + GET + ACCESS_KEY_UNSPLASH;
 

--- a/src/utils/SchemaManager.vala
+++ b/src/utils/SchemaManager.vala
@@ -27,7 +27,9 @@ namespace App.Utils {
 
     public class SchemaManager {
         private GLib.Settings settings;
+        private GLib.Settings settings_screensaver;
         private const string gnome_background_schema = "org.gnome.desktop.background";
+        private const string gnome_screensaver_schema = "org.gnome.desktop.screensaver";
         private const string mate_background_schema = "org.mate.background";
 
         private int env = Constants.IS_GNOME;
@@ -50,8 +52,14 @@ namespace App.Utils {
                 if (schema != null) {
                     settings = new GLib.Settings.full (schema, null, null);
                     env = Constants.IS_GNOME;
+
+                    var schema_screensaver = schema_source.lookup (gnome_screensaver_schema, true);
+                    if (schema_screensaver != null) {
+                        settings_screensaver = new GLib.Settings.full (schema_screensaver, null, null);
+                    }
                     return;
                 }
+
             } catch (Error e) {
                 print (e.message);
             }
@@ -62,6 +70,9 @@ namespace App.Utils {
                 switch (env) {
                     case Constants.IS_GNOME:
                         settings.set_string ("picture-uri", "file://" + picture_path);
+                        if (settings_screensaver != null) {
+                            settings_screensaver.set_string ("picture-uri", "file://" + picture_path);
+                        }
                         break;
                     case Constants.IS_MATE:
                         settings.set_string ("picture-filename", picture_path);


### PR DESCRIPTION
[Issue #63 - No way to set the lock screen background ](https://github.com/calo001/fondo/issues/63)
When GNOME3 is detected it will attempt to change the GDM lockscreen wallpaper. 
- detect lockscreen schema 
- apply lockscreen wallpaper
- fixed install dependencies bash script