### PR TITLE
Minor alignment changes for menu_button

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -105,6 +105,7 @@ namespace App.Widgets {
              * Menú options button
              */
             var menu_button = new Gtk.Button.from_icon_name ("view-more-horizontal-symbolic", Gtk.IconSize.LARGE_TOOLBAR );
+            menu_button.valign = Gtk.Align.CENTER;
             menu_button.tooltip_text = S.ABOUT;
 
             var pop_menu = new MenuPopover (menu_button);


### PR DESCRIPTION
Just added vertical alignment for 'menu_button' which gives a good look for the button when clicking.

Before:
![old](https://user-images.githubusercontent.com/47270790/72910554-b3252e80-3d5e-11ea-8413-bc5db71ff3f3.png)

Now:
![old2](https://user-images.githubusercontent.com/47270790/72910612-c932ef00-3d5e-11ea-9187-1167e427782b.png)
