### PR TITLE
'cd' for non-existent clone folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Use the App script to simplify installation by running `./app install-deps`, in 
  ### Building
 
 ```
-git clone https://github.com/calo001/fondo.git && cd com.github.calo001.fondo
+git clone https://github.com/calo001/fondo.git && cd fondo
 ./app install-deps && ./app install
 ```
 


### PR DESCRIPTION
The cloned folder by git is only called "fondo" and not the whole package name. Changed that for convenience.