### PR TITLE
Include orientation label in i18n strings

### DIFF
--- a/po/com.github.calo001.fondo.pot
+++ b/po/com.github.calo001.fondo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.calo001.fondo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-11 23:50-0600\n"
+"POT-Creation-Date: 2020-12-26 22:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -349,4 +349,8 @@ msgstr ""
 #: src/Configs/Strings.vala:109
 #, c-format
 msgid "The link %s has been copied to the clipboard!"
+msgstr ""
+
+#: src/Configs/Strings.vala:110
+msgid "Orientation"
 msgstr ""

--- a/src/Configs/Strings.vala
+++ b/src/Configs/Strings.vala
@@ -107,5 +107,6 @@ namespace App.Configs {
         public abstract const string CANCEL_BUTTON = _("Cancel");
         public abstract const string CLIPBOARD_TITLE_NOTIFICATION = _("Share photo");
         public abstract const string CLIPBOARD_MSG_NOTIFICATION = _("The link %s has been copied to the clipboard!");
+        public abstract const string ORIENTATION = _("Orientation");
     }
 }

--- a/src/Views/FilterOptionsView.vala
+++ b/src/Views/FilterOptionsView.vala
@@ -55,7 +55,7 @@ namespace App.Views {
             button_portrait.join_group (button_landscape);
             button_any.join_group (button_landscape);
 
-            var lbl_filter = new Gtk.Label ("Orientation");
+            var lbl_filter = new Gtk.Label (S.ORIENTATION);
             lbl_filter.get_style_context ().add_class ("filter_option");
 
             button_landscape.clicked.connect ( () => {


### PR DESCRIPTION
Hi there,

I noticed that the orientation in the top right popup was hardcoded in English. This PR adds it among the other i18n strings.